### PR TITLE
update the version to match the next release

### DIFF
--- a/backup-station
+++ b/backup-station
@@ -9,7 +9,7 @@ import pwd
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
-__VERSION__ = '0.1'
+__VERSION__ = '0.3'
 
 gettext.bindtextdomain('backup-station', '/usr/local/share/locale')
 gettext.textdomain('backup-station')


### PR DESCRIPTION
We missed updating the number for version and release 0.2. This is version 0.3 and I can create a release to match.