### PR TITLE
correct how be_name is selected

### DIFF
--- a/backup-station
+++ b/backup-station
@@ -68,7 +68,7 @@ class BackupStationWindow(Gtk.Window):
         dialog.destroy()
 
     def activate_be(self, button):
-        bename = self.select_be()
+        bename = self.select_be()[0]
         bectl.activate_be(bename)
         self.refresh_be_list()
 
@@ -95,12 +95,12 @@ class BackupStationWindow(Gtk.Window):
         dialog.destroy()
 
     def mount_be(self, button):
-        bename = self.select_be()
+        bename = self.select_be()[0]
         bectl.mount_be(bename)
         self.refresh_be_list()
 
     def umount_be(self, button):
-        bename = self.select_be()
+        bename = self.select_be()[0]
         bectl.umount_be(bename)
         self.refresh_be_list()
 


### PR DESCRIPTION
This should fix my error that I didn't notice for the 0.3 release. That bug prevented activating, mounting, and unmounting the boot environment.